### PR TITLE
Disables recaptcha for ip addresses set in options

### DIFF
--- a/no-captcha.php
+++ b/no-captcha.php
@@ -235,14 +235,6 @@ function wr_no_captcha_get_client_ip() {
 	$ipaddress = '';
 	if (isset($_SERVER['HTTP_CLIENT_IP']))
 		$ipaddress = $_SERVER['HTTP_CLIENT_IP'];
-	else if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
-		$ipaddress = $_SERVER['HTTP_X_FORWARDED_FOR'];
-	else if(isset($_SERVER['HTTP_X_FORWARDED']))
-		$ipaddress = $_SERVER['HTTP_X_FORWARDED'];
-	else if(isset($_SERVER['HTTP_FORWARDED_FOR']))
-		$ipaddress = $_SERVER['HTTP_FORWARDED_FOR'];
-	else if(isset($_SERVER['HTTP_FORWARDED']))
-		$ipaddress = $_SERVER['HTTP_FORWARDED'];
 	else if(isset($_SERVER['REMOTE_ADDR']))
 		$ipaddress = $_SERVER['REMOTE_ADDR'];
 	else


### PR DESCRIPTION
Comes in handy if your ip address is static. We added this feature by customer's request and would be glad if you could include it so the extension stays updatable.