### PR TITLE
Fix behind a proxy IP address check

### DIFF
--- a/no-captcha.php
+++ b/no-captcha.php
@@ -240,10 +240,10 @@ function wr_no_captcha_get_exlude_ips() {
 
 function wr_no_captcha_get_client_ip() {
 	$ipaddress = '';
-	if ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-		$ipaddress = $_SERVER['HTTP_CLIENT_IP'];
-	} elseif ( get_option( 'wr_no_captcha_exlude_ips_forwarded_for' ) === '1' && isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+	if ( get_option( 'wr_no_captcha_exlude_ips_forwarded_for' ) === '1' && isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 		$ipaddress = $_SERVER['HTTP_X_FORWARDED_FOR'];
+	} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+		$ipaddress = $_SERVER['HTTP_CLIENT_IP'];
 	} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
 		$ipaddress = $_SERVER['REMOTE_ADDR'];
 	} else {

--- a/no-captcha.php
+++ b/no-captcha.php
@@ -242,10 +242,10 @@ function wr_no_captcha_get_client_ip() {
 	$ipaddress = '';
 	if ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
 		$ipaddress = $_SERVER['HTTP_CLIENT_IP'];
-	} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
-		$ipaddress = $_SERVER['REMOTE_ADDR'];
 	} elseif ( get_option( 'wr_no_captcha_exlude_ips_forwarded_for' ) === '1' && isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 		$ipaddress = $_SERVER['HTTP_X_FORWARDED_FOR'];
+	} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+		$ipaddress = $_SERVER['REMOTE_ADDR'];
 	} else {
 		$ipaddress = 'UNKNOWN';
 	}


### PR DESCRIPTION
Hi, this is my first pull request, I hope I'm doing it OK.

The "if behind a proxy" address check would never trigger because `_SERVER['REMOTE_ADDR']` is always set.  PHP sees that variable is set and stops processing the remaining conditions.

By moving the `_SERVER['REMOTE_ADDR']` condition lower in the elseif group I can get the "behind a proxy" check to trigger and work.